### PR TITLE
Try/catch on thread/sleep

### DIFF
--- a/src-inst/flow_storm/mem_reporter.cljc
+++ b/src-inst/flow_storm/mem_reporter.cljc
@@ -17,7 +17,7 @@
                          (let [heap-info (utils/get-memory-info)
                                ev (rt-events/make-heap-info-update-event heap-info)]
                            (rt-events/publish-event! ev)
-                           (try (Thread/sleep 1000) (catch InterruptedException e (println "Flowstorm Closed")))
+                           (try (Thread/sleep reporter-interval) (catch InterruptedException _ (println "Flowstorm Closed")))
                            (recur)))))
                    "FlowStorm Memory Reporter")
            interrupt-fn (fn [] (.interrupt thread))]

--- a/src-inst/flow_storm/mem_reporter.cljc
+++ b/src-inst/flow_storm/mem_reporter.cljc
@@ -17,7 +17,7 @@
                          (let [heap-info (utils/get-memory-info)
                                ev (rt-events/make-heap-info-update-event heap-info)]
                            (rt-events/publish-event! ev)
-                           (Thread/sleep reporter-interval)
+                           (try (Thread/sleep 1000) (catch InterruptedException e (println "Flowstorm Closed")))
                            (recur)))))
                    "FlowStorm Memory Reporter")
            interrupt-fn (fn [] (.interrupt thread))]


### PR DESCRIPTION
There's been a stack trace error whenever I close flowstorm. It seems like there's a check if the thread has been interrupted at loop start, but nothing catching when a thread is closed in the middle of sleep. 

Don't know if you want this, or want it to print anything, but it'd be nice to not have a stacktrace when closing