### PR TITLE
Fix CSS load order so fonts load last (resizing)

### DIFF
--- a/src-dbg/flow_storm/debugger/state.clj
+++ b/src-dbg/flow_storm/debugger/state.clj
@@ -332,9 +332,9 @@
         extra-styles (when extra-styles
                        (str (io/as-url (io/file extra-styles))))]
     (cond-> [theme-base-styles
-             default-styles
-             font-size-style]
-      extra-styles (conj extra-styles))))
+             default-styles]
+      extra-styles (conj extra-styles)
+      true (conj font-size-style))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; JFX objects index ;;


### PR DESCRIPTION
Fixes CSS stylesheet load order so that font resizing works with custom stylesheets, as well.