### PR TITLE
Check for `:flow-storm.power-step/skip` value when power stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## master (unreleased)
 	
 ### New Features
-    
+
+    - Check for `:flow-storm.power-step/skip` value when power stepping
+
 ### Changes
              
 ### Bugs fixed

--- a/src-inst/flow_storm/runtime/indexes/api.cljc
+++ b/src-inst/flow_storm/runtime/indexes/api.cljc
@@ -822,6 +822,7 @@
     (fn [entry-form-id _ tl-entry]
       (when (and (or (fn-return-trace/fn-return-trace? tl-entry)
                      (expr-trace/expr-trace? tl-entry))
+                 (not (identical? (index-protos/get-expr-val tl-entry) :flow-storm.power-step/skip))
                  (if (contains? criteria :identity-val) (identical? (index-protos/get-expr-val tl-entry) identity-val)  true)
                  (if (contains? criteria :equality-val) (= (index-protos/get-expr-val tl-entry) equality-val)           true)
                  (if coord           (= coord (index-protos/get-coord-raw tl-entry))                 true)


### PR DESCRIPTION
We can return this, for example, when snapshotting. Useful for heavy values (e.g. textures, audio etc).

It won't interfere with the recording, only when power stepping.