### PR TITLE
Update user_guide.adoc

### DIFF
--- a/docs/user_guide.adoc
+++ b/docs/user_guide.adoc
@@ -1692,7 +1692,7 @@ Take a look at their docstrings for more info.
 You can teach a LLM how to use FlowStorm's api to help you analyze your recordings.
 
 If you are using the amazing https://github.com/bhauman/clojure-mcp[clojure-mcp] you just need to upload
-(https://github.com/flow-storm/flow-storm-debugger/blob/master/llm-prompt.txt)[one more file] that teaches the LLM FlowStorm's basics from the repl.
+https://github.com/flow-storm/flow-storm-debugger/blob/master/llm-prompt.txt[one more file] that teaches the LLM FlowStorm's basics from the repl.
 
 https://claude.ai/share/489c9124-b1a8-4a33-b50a-52e4f3d4709f[Here] is a very basic chat asking Claude to look at some recordings of a buggy
 TODO's web application.


### PR DESCRIPTION
I'm not sure if my fix is ​​correct, but the link doesn't work now because the rendered version contains extra brackets at the beginning and end.